### PR TITLE
Upgrade to Steal 0.7.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
 		"steal-export": {
 			dist: {
 				system: {
-					config: "package.json!npm"
+					configMain: "package.json!npm"
 				},
 				outputs: {
 					"+cjs": {},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bit-tabs",
   "version": "0.0.2-pre.0",
   "description": "",
-  "main": "dist/cjs/lib/bit-tabs",
+  "main": "dist/cjs/bit-tabs",
   "browser": {
     "transform": [ "cssify" ]
   },
@@ -22,14 +22,18 @@
     "grunt": "~0.4.1",
     "grunt-cli": "^0.1.13",
     "jquery": ">1.9.0",
-    "steal": "0.6.0-pre.0",
-    "steal-tools": "0.6.0-pre.2",
+    "steal": "~0.7.0",
+    "steal-tools": "~0.7.0",
     "steal-qunit": "0.0.2",
     "testee": "^0.1.8"
   },
   "system": {
-    "main": "src/bit-tabs",
-    "npmIgnore": ["testee","cssify"]
+    "main": "bit-tabs",
+    "npmIgnore": ["testee","cssify"],
+    "directories": {
+      "lib": "src"
+    },
+    "transpiler": "babel"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This upgrades the library to use Steal 0.7.0 including the use of
`directories.lib` and Babel as the `transpiler`. Closes #1
