### PR TITLE
Show the first tab as the active tab by default

### DIFF
--- a/src/tabs.stache
+++ b/src/tabs.stache
@@ -1,6 +1,6 @@
 <ul class="{{tabsClass}}">
   {{#panels}}
-    <li {{#isActive}}class='active'{{/isActive}}
+    <li {{#if isActive(.)}}class='active'{{/if}}
     	can-click='makeActive'>
 		  <a href="javascript://">{{title}}</a>
 	</li>

--- a/test/tabs_test.js
+++ b/test/tabs_test.js
@@ -27,6 +27,7 @@ QUnit.module("bit-tabs component",{
 QUnit.test("basics", function(){
   F("bit-tabs ul li").text(/First/, "has text");
   F("bit-tabs ul").hasClass("nav", true).hasClass("nav-tabs", true, "tabsClass gets assigned to ul");
+  F("bit-tabs ul li").hasClass("active", true, "first tab has active class");
 });
 
 QUnit.test("clicking works", function(){


### PR DESCRIPTION
This fixes a bug where the active tab was not selected by default.

Before:
<img width="421" alt="screen shot 2017-05-22 at 5 55 35 pm" src="https://cloud.githubusercontent.com/assets/10070176/26334169/f00b95d4-3f17-11e7-8f75-9cbb277fe39c.png">

After:
<img width="420" alt="screen shot 2017-05-22 at 5 55 13 pm" src="https://cloud.githubusercontent.com/assets/10070176/26334172/f598631a-3f17-11e7-8c05-625ecf1f4924.png">

Fixes #24 
