### PR TITLE
added specific parent scope to look for isActive in

### DIFF
--- a/src/tabs.stache
+++ b/src/tabs.stache
@@ -1,6 +1,6 @@
 <ul class="{{tabsClass}}">
   {{#panels}}
-    <li {{#if isActive(.)}}class='active'{{/if}}
+    <li {{#if ../isActive(.)}}class='active'{{/if}}
     	can-click='makeActive'>
 		  <a href="javascript://">{{title}}</a>
 	</li>

--- a/src/unstyled.js
+++ b/src/unstyled.js
@@ -15,7 +15,7 @@ export var BitPanelVM = CanMap.extend({
 Component.extend({
 	tag:"bit-panel",
 	view: panelStache,
-	viewModel: BitPanelVM,
+	ViewModel: BitPanelVM,
 	events: {
 		inserted: function(){
       canViewModel(this.element.parentNode).addPanel(this.viewModel);
@@ -78,5 +78,5 @@ export var BitTabsVM = CanMap.extend({
 Component.extend({
 	tag: "bit-tabs",
 	view: tabsStache,
-	viewModel: BitTabsVM
+	ViewModel: BitTabsVM
 });


### PR DESCRIPTION
This adds the specific parent scope before `isActive()` so that it doesn't have to look up the scope to find it as we will be removing that in a future release.

Closes https://github.com/bitovi-components/bit-tabs/issues/26